### PR TITLE
Supprime les notifs Dead ou de Réveil manqué quand l'équipement est désactivé

### DIFF
--- a/core/class/zwavejs.class.php
+++ b/core/class/zwavejs.class.php
@@ -845,7 +845,7 @@ class zwavejs extends eqLogic {
 							$eqLogic->setConfiguration('lastWakeUp', time());
 							if ($eqLogic->getConfiguration('missedWakeup', false)){
 								$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
-								if (config::byKey('notifyMissWakeup', __CLASS__, 1)==1){
+								if (config::byKey('notifyMissWakeup', __CLASS__, 1)==1 && $eqLogic->getIsEnable()==1){
 									if (version_compare(jeedom::version(),'4.4.0','>=')){
 										message::add('zwavejs',"L'équipement : " . $eqLogic->getHumanName(true) . ' avec le nodeId : ' . $eqLogic->getLogicalId(). ', vient de se réveiller après avoir raté au minimum 4 réveils.', $action,'Awake-'.$eqLogic->getLogicalId(),true,'alerting');
 									} else {
@@ -858,7 +858,7 @@ class zwavejs extends eqLogic {
 						}
 						if ($data['status'] == 'Dead' && $currentValue == 'Alive') {
 							$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
-							if (config::byKey('notifyDead', __CLASS__, 1)==1){
+							if (config::byKey('notifyDead', __CLASS__, 1)==1 && $eqLogic->getIsEnable()==1){
 								if (version_compare(jeedom::version(),'4.4.0','>=')){
 									message::add('zwavejs',"L'équipement : " . $eqLogic->getHumanName(true) . ' avec le nodeId : ' . $eqLogic->getLogicalId(). ', vient de passer au statut Dead.', $action,'Dead-'.$eqLogic->getLogicalId(),true,'alerting');
 								} else {
@@ -868,7 +868,7 @@ class zwavejs extends eqLogic {
 						}
 						if ($data['status'] == 'Alive' && $currentValue == 'Dead') {
 							$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
-							if (config::byKey('notifyDead', __CLASS__, 1)==1){
+							if (config::byKey('notifyDead', __CLASS__, 1)==1 && $eqLogic->getIsEnable()==1){
 								if (version_compare(jeedom::version(),'4.4.0','>=')){
 									message::add('zwavejs',"L'équipement : " . $eqLogic->getHumanName(true) . ' avec le nodeId : ' . $eqLogic->getLogicalId(). ', vient de passer au statut Alive.', $action,'Alive-'.$eqLogic->getLogicalId(),true,'alertingReturnBack');
 								} else {
@@ -1503,7 +1503,7 @@ class zwavejs extends eqLogic {
 						}
 						if ($wakedup > 3*$values['values']['132-0-wakeUpInterval']['value']) {
 							$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
-							if (config::byKey('notifyMissWakeup', __CLASS__, 1)==1){
+							if (config::byKey('notifyMissWakeup', __CLASS__, 1)==1 && $eqLogic->getIsEnable()==1){
 								if (version_compare(jeedom::version(),'4.4.0','>=')){
 									message::add('zwavejs',"L'équipement : " . $eqLogic->getHumanName(true) . ' avec le nodeId : ' . $eqLogic->getLogicalId(). ", ne s'est pas reveillé au moins 4 fois. Il a peut être un problème (batterie ou autres).", $action,'Wakeup-'.$eqLogic->getLogicalId(),true,'alertingReturnBack');
 								} else {


### PR DESCRIPTION
Supprime les notifications Dead ou de Réveil manqué quand l'équipement est désactivé

## Description
Quand un équipement est désactivé, les notifications d'équipement Dead et de réveil manqué continue à se produire.

### Suggested changelog entry
Supprime les notifications Dead ou de Réveil manqué quand l'équipement est désactivé

## Types of changes
- [X] Bug fix

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [X] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.

