### PR TITLE
Remove escaped quote

### DIFF
--- a/desktop/php/zwavejs.php
+++ b/desktop/php/zwavejs.php
@@ -25,9 +25,9 @@ $eqLogics = eqLogic::byType($plugin->getId());
 $controllerStatus = config::byKey('controllerStatus', 'zwavejs', 'none');
 $driverStatus = config::byKey('driverStatus', 'zwavejs', 0);
 if (!zwavejs::isRunning()) {
-	echo '<div id="div_driverStatus"><div class="alert alert-danger" role="alert"> {{Le démon Z-Wave n\'est pas démarré.}}</div></div>';
+	echo '<div id="div_driverStatus"><div class="alert alert-danger" role="alert"> {{Le démon Z-Wave n’est pas démarré.}}</div></div>';
 } else if ($driverStatus != 1) {
-	echo '<div id="div_driverStatus"><div class="alert alert-warning" role="alert"> {{Le driver Z-Wave n\'est pas initialisé, veuillez patienter. Si le message reste trop longtemps, veuillez vérifier la configuration du démon}}</div></div>';
+	echo '<div id="div_driverStatus"><div class="alert alert-warning" role="alert"> {{Le driver Z-Wave n’est pas initialisé, veuillez patienter. Si le message reste trop longtemps, veuillez vérifier la configuration du démon}}</div></div>';
 } else {
 	echo '<div id="div_driverStatus"></div>';
 }


### PR DESCRIPTION
## Description

`Le démon Z-Wave n\'est pas démarré.` is displayed in the configuration page. Replacing `\'` by `’`.

### Suggested changelog entry

en: Correct quote in messages.
fr: Corriger l'apostrophe dans les messages.

### Related issues/external references

None

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
- [x] Typo

## PR checklist
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [X] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [X] N/A  [Required for new sniffs] I have added MD documentation for the sniff.
