### PR TITLE
try 9.27.2 ZwaveJsUI

### DIFF
--- a/core/config/zwavejs.config.ini
+++ b/core/config/zwavejs.config.ini
@@ -1,5 +1,5 @@
 [zwavejs]
-wantedVersion=9.20.0
+wantedVersion=9.27.2
 prefix=zwave
 auto_applyRecommended=1
 autoRemoveExcludeDevice=1

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -4,6 +4,7 @@
 >
 >S'il n'y a pas d'information sur la mise à jour, c'est que celle-ci concerne uniquement de la mise à jour de documentation, de traduction ou de texte.
 
+- Passage à la version *9.27.2* de ZwaveJsUI
 - Ajout du mode distant *(Attention: cela réduit les fonctionnalités du plugin)*. Bien lire la documentation, le passage en mode distant à un fort impact sur la simplicité d'utilisation et la compatibilité de certains modules
 - Support du protocole mqtts
 


### PR DESCRIPTION
# Bump ZwaveJS UI to 9.27.2

## Description
Try last ZwaveJS UI version (9.27.2)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
